### PR TITLE
adds a returns argument to webpi_product resource

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'https://supermarket.chef.io'
+source 'http://berkshelf-api.articulate.com'
 
 metadata

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Microsoft Web Platform Installer (WebPI) automates the installation of Microsoft
 #### Attribute Parameters
 - product_id: name attribute. Specifies the ID of a product to install.
 - accept_eula: specifies that WebpiCmdline should auto-accept EULAs. Default is false.
+- returns: specifies the return value(s) expected for a successful installation. Can be a single integer or array of integers.  Default is [0, 42]
 
 #### Examples
 Install IIS 7 Recommended Configuration (will install IIS 8 on Windows 2012 despite the name)
@@ -50,6 +51,16 @@ Install Windows PowerShell 2.0
 webpi_product 'PowerShell2' do
   accept_eula true
   action :install
+end
+```
+
+Install Windows Azure Powershell 1.0 (will return a 3010 exit code to signify a successful installation that requires a reboot)
+
+```ruby
+webpi_product 'WindowsAzurePowerShellGet' do
+  accept_eula true
+  action :install
+  returns 3010
 end
 ```
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache 2.0'
 description      'Installs/Configures the Microsoft Web Platform Installer (WebPI)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.0'
+version          '2.0.1'
 supports         'windows'
 depends          'windows', '>= 1.39.0'
 

--- a/providers/product.rb
+++ b/providers/product.rb
@@ -35,7 +35,7 @@ action :install do
       cmd << ' /accepteula' if @new_resource.accept_eula
       cmd << " /XML:#{node['webpi']['xmlpath']}" if node['webpi']['xmlpath']
       cmd << " /Log:#{node['webpi']['log']}"
-      shell_out!(cmd, returns: [0, 42])
+      shell_out!(cmd, returns: @new_resource.returns)
     end
   end
 end

--- a/resources/product.rb
+++ b/resources/product.rb
@@ -23,3 +23,4 @@ default_action :install
 
 attribute :product_id, kind_of: String, name_attribute: true
 attribute :accept_eula, kind_of: [TrueClass, FalseClass], default: false
+attribute :returns, kind_of: [Integer, Array], default: [0, 42]


### PR DESCRIPTION
adds a returns argument to webpi_product resource; was getting `3010` (reboot required) return values from the 'WindowsAzurePowerShellGet' installation that were failing the chef run...even though the installation was successful.

```
================================================================================
Error executing action `install` on resource 'webpi_product[WindowsAzurePowerShellGet]'
================================================================================

Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0, 42], but received '3010'
```